### PR TITLE
Ruby MergeWorker#hash_string doesn't check File modification time

### DIFF
--- a/lib/iron_worker_ng/feature/ruby/merge_worker.rb
+++ b/lib/iron_worker_ng/feature/ruby/merge_worker.rb
@@ -12,7 +12,7 @@ module IronWorkerNG
           end
 
           def hash_string
-            Digest::MD5.hexdigest(@path + @klass)
+            Digest::MD5.hexdigest(@path + @klass + File.mtime(@path).to_i.to_s)
           end
 
           def bundle(zip)


### PR DESCRIPTION
The Ruby [MergeWorker::Feature#hash_string](https://github.com/iron-io/iron_worker_ruby_ng/blob/master/lib/iron_worker_ng/feature/ruby/merge_worker.rb#L15) doesn't hash the modification time of the worker file. That means that the path has to be changed to invalidate workers.

It looks like all of the other merge_\* directives ([Common MergeFile::Feature#hash_string](https://github.com/iron-io/iron_worker_ruby_ng/blob/master/lib/iron_worker_ng/feature/common/merge_file.rb#L15), [Common MergeDir::Feature#hash_string](https://github.com/iron-io/iron_worker_ruby_ng/blob/master/lib/iron_worker_ng/feature/common/merge_dir.rb#L15), [Java MergeJar::Feature#hash_string](https://github.com/iron-io/iron_worker_ruby_ng/blob/master/lib/iron_worker_ng/feature/java/merge_jar.rb#L13)) include a call or calls to `File.mtime`, and the workers ([Java MergeWorker::Feature#hash_string](https://github.com/iron-io/iron_worker_ruby_ng/blob/master/lib/iron_worker_ng/feature/java/merge_worker.rb#L15), [Node MergeWorker::Feature#hash_string](https://github.com/iron-io/iron_worker_ruby_ng/blob/master/lib/iron_worker_ng/feature/node/merge_worker.rb#L13)) seem to follow the pattern `@path + @klass (if available) + File.mtime(@path).to_i.to_s`.

This commit appends `File.mtime(@path).to_i.to_s` to the Ruby `MergeWorker::Feature#hash_string` input data, matching the other class input formats.
