### PR TITLE
Fix variable name in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ schedule = client.schedules.create('MyWorker', {:client => 'Joe'}, {:start_at =>
 puts schedule.id
 ```
 
-### schedules.cancel(schdule_id)
+### schedules.cancel(schedule_id)
 
 Cancels schedule with specified schedule_id.
 


### PR DESCRIPTION
The example for `schedules.cancel` had `schdule_id` instead of `schedule_id` as the parameter name.
