### PR TITLE
Add runner for node runtime

### DIFF
--- a/lib/iron_worker_ng/code/runtime/node.rb
+++ b/lib/iron_worker_ng/code/runtime/node.rb
@@ -15,7 +15,7 @@ var task_id = null;
 
 process.argv.forEach(function(val, index, array) {
   if (val == "-payload") {
-    params = JSON.parse(fs.readFileSync(process.argv[index + 1], 'ascii'));
+    params = JSON.parse(fs.readFileSync(process.argv[index + 1], 'utf8'));
   }
 
   if (val == "-id") {


### PR DESCRIPTION
Add runner for node runtime.

Usage example:

``` js
var iw = require('node_helper');
console.log("params:", iw.params);
console.log("task_id:", iw.task_id);

```

Well, 'node_helper' name feels....unrelated. Any better candidates?
