### PR TITLE
allow simple pip package version

### DIFF
--- a/lib/iron_worker_ng/feature/python/merge_pip.rb
+++ b/lib/iron_worker_ng/feature/python/merge_pip.rb
@@ -41,7 +41,7 @@ module IronWorkerNG
 
             ::Dir.mkdir(pips_dir_name)
 
-            deps_string = @deps.map { |dep| dep.version == '' ? dep.name : dep.name + dep.version }.join(' ')
+            deps_string = @deps.map { |dep| dep.name + dep.version.to_s.sub(/\A\d/, '==\0') }.join(' ')
             install_command = pip_binary + ' install -U -I --user --root ' + pips_dir_name + ' ' + deps_string
 
             fork do


### PR DESCRIPTION
allow simple pip package version

``` ruby
pip "iron-worker", "==1.2.0" # was, original format
pip "iron-worker", "1.2.0" # new
```
