### PR TITLE
send iron_task_id if exec_inst responds to iron_task_id=

### DIFF
--- a/lib/iron_worker_ng/code/runtime/ruby.rb
+++ b/lib/iron_worker_ng/code/runtime/ruby.rb
@@ -106,6 +106,10 @@ unless #{@exec.arg(:class, 0) == nil}
     end
   end
 
+  if exec_inst.respond_to?(:iron_task_id=)
+    exec_inst.send(:iron_task_id=, iron_task_id)
+  end
+
   exec_inst.run
 end
 RUBY_RUNNER


### PR DESCRIPTION
For one of my projects it would be useful if iron_task_id is send to the executed instance, just like the params are being sent. Are there tests defined for the params, because I couldn't find them.
