### PR TITLE
add environment variable to node_helper.js

### DIFF
--- a/lib/iron_worker_ng/code/runtime/node.rb
+++ b/lib/iron_worker_ng/code/runtime/node.rb
@@ -13,6 +13,7 @@ var fs = require('fs');
 var params = null;
 var task_id = null;
 var config = null;
+var env = null;
 
 process.argv.forEach(function(val, index, array) {
   if (val == "-payload") {
@@ -22,6 +23,10 @@ process.argv.forEach(function(val, index, array) {
   if (val == "-config") {
     config = JSON.parse(fs.readFileSync(process.argv[index + 1], 'utf8'));
   }
+  
+    if (val == "-e") {
+    env = JSON.parse(fs.readFileSync(process.argv[index + 1], 'utf8'));
+  }
 
   if (val == "-id") {
     task_id = process.argv[index + 1];
@@ -30,6 +35,7 @@ process.argv.forEach(function(val, index, array) {
 
 exports.params = params;
 exports.config = config;
+exports.env = env;
 exports.task_id = task_id;
 
 NODE_RUNNER


### PR DESCRIPTION
needed when accessing a nested project_id/token from within a node worker for the purposes of setting up a iron_mq client correctly
