### PR TITLE
payload can accept a querystring

### DIFF
--- a/lib/iron_worker_ng/code/runtime/node.rb
+++ b/lib/iron_worker_ng/code/runtime/node.rb
@@ -10,13 +10,18 @@ module IronWorkerNG
 /* #{IronWorkerNG.full_version} */
 
 var fs = require('fs');
+var querystring = require('querystring');
 var params = null;
 var task_id = null;
 var config = null;
 
 process.argv.forEach(function(val, index, array) {
   if (val == "-payload") {
-    params = JSON.parse(fs.readFileSync(process.argv[index + 1], 'utf8'));
+    try {
+      params = JSON.parse(fs.readFileSync(process.argv[index + 1], 'utf8'));
+    } catch(e) {
+      params = querystring.parse(fs.readFileSync(process.argv[index + 1], 'utf8'))
+    }
   }
 
   if (val == "-config") {


### PR DESCRIPTION
If using a webhook, the payload is a querystring (at least with twilio), which JSON cannot parse.  This causes the script to fail with a Syntax Error.

Added try/catch block to retry with querystring.
