### PR TITLE
--task-delay parameter for scheduled tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,10 @@ puts schedule.id
   - **run_times**: The number of times a task will run.
   - **priority**: Setting the priority of your job. Valid values are 0, 1, and 2. The default is 0. Higher values means tasks spend less time in the queue once they come off the schedule.
   - **start_at**: The time the scheduled task should first be run.
+  - **timeout**: The maximum runtime of your task in seconds. No task can exceed 3600 seconds (60 minutes). The default is 3600 but can be set to a shorter duration.
+  - **delay**: The number of seconds to delay before scheduling the tasks. Default is 0.
+  - **task_delay**: The number of seconds to delay before actually queuing the task. Default is 0.
+  - **cluster**: cluster name ex: "high-mem" or "dedicated".  This is a premium feature for customers for customers to have access to more powerful or custom built worker solutions. Dedicated worker clusters exist for users who want to reserve a set number of workers just for their queued tasks. If not set default is set to  "default" which is the public IronWorker cluster.
 
 ### schedules.cancel(schedule_id)
 

--- a/bin/iron_worker
+++ b/bin/iron_worker
@@ -175,7 +175,8 @@ elsif command == 'queue' || command == 'schedule'
       options[:timeout] = v
     end
 
-    opts.on('--delay DELAY', Integer, 'delay before start in seconds') do |v|
+    desc = command == 'queue' ? 'delay before start in seconds' : 'delay before scheduling tasks in seconds'
+    opts.on('--delay DELAY', Integer, desc) do |v|
       options[:delay] = v
     end
 
@@ -190,6 +191,10 @@ elsif command == 'queue' || command == 'schedule'
     end
 
     if command == 'schedule'
+      opts.on('--task-delay DELAY', Integer, 'delay before start of task in seconds') do |v|
+        options[:task_delay] = v
+      end
+
       opts.on('--start-at TIME', 'start task at specified time') do |v|
         options[:start_at] = Time.parse(v)
       end


### PR DESCRIPTION
Added --task-delay parameter for 'iron_worker schedule' command. This is to set the delay for tasks. '--delay' parameter is used for delay for scheduled_task. It just adds that delay to 'start_at' parameter.

@thousandsofthem 
