### PR TITLE
added bulk create method for posting 1+ N tasks in single api call

### DIFF
--- a/lib/iron_worker_ng/api_client.rb
+++ b/lib/iron_worker_ng/api_client.rb
@@ -82,7 +82,20 @@ module IronWorkerNG
     end
 
     def tasks_create(code_name, payload, options = {})
+      # creates single task
+      # could not make tasks_create(code_name, payload, options = {}) backwards compatible for batch tasks an array payload value could potentially be a legitimate payload rather than an array of tasks @stephenitis
       parse_response(post("projects/#{@project_id}/tasks", {:tasks => [{:code_name => code_name, :payload => payload}.merge(options)]}))
+    end
+
+    def tasks_bulk_create(code_name, array_of_payloads, options)
+      # batch post tasks
+      array_of_tasks = array_of_payloads.map! do |payload|
+        {
+          :code_name => code_name,
+          :payload => payload.is_a?(String) ? payload : payload.to_json
+        } .merge(options)
+      end
+        parse_response(post("projects/#{@project_id}/tasks", {:tasks => array_of_tasks}))
     end
 
     def tasks_cancel(id)

--- a/lib/iron_worker_ng/client.rb
+++ b/lib/iron_worker_ng/client.rb
@@ -313,6 +313,14 @@ EXEC_FILE
       OpenStruct.new(t)
     end
 
+    def tasks_bulk_create(code_name, params = [], options = {})
+      IronCore::Logger.debug 'IronWorkerNG', "Calling tasks.bulk_create_legacy with code_name='#{code_name}', params='#{params.to_s}' and options='#{options.to_s}'"
+
+      res = @api.tasks_bulk_create(code_name, params.is_a?(Array) ? params : params.to_json, options)
+
+      OpenStruct.new(res)
+    end
+
     def tasks_create_legacy(code_name, params = {}, options = {})
       IronCore::Logger.debug 'IronWorkerNG', "Calling tasks.create_legacy with code_name='#{code_name}', params='#{params.to_s}' and options='#{options.to_s}'"
 


### PR DESCRIPTION
The api allows for bulk posting of tasks but the ruby but the tasks.create method was not changeable to fit this behavior without possibly breaking code where previous users would have an array as their payload rather than an array of payloads.

```ruby
p client.tasks.bulk_create('hello_ruby', Array.new(100) {|i| {:hello => "world"} }, {:cluster => "mem1"} )
```