### PR TITLE
Fix a bug: code_post ignores file-attachment if no file_name specified

### DIFF
--- a/lib/iron_worker_ng/api_client.rb
+++ b/lib/iron_worker_ng/api_client.rb
@@ -48,7 +48,7 @@ module IronWorkerNG
     end
 
     def codes_create(name, file, runtime, runner, options)
-      file_instance = file.to_s.strip ==  "" || runner.to_s.strip == "" ? "" : File.new(file, 'rb')
+      file_instance = file.to_s.strip ==  '' ? '' : File.new(file, 'rb')
       options = {:name => name, :runtime => runtime, :file_name => runner}.merge(options)
       parse_response(post_file("projects/#{@project_id}/codes", :file, file_instance, :data, options))
     end

--- a/lib/iron_worker_ng/version.rb
+++ b/lib/iron_worker_ng/version.rb
@@ -1,5 +1,5 @@
 module IronWorkerNG
-  VERSION = '1.6.4'
+  VERSION = '1.6.6'
 
   def self.version
     VERSION


### PR DESCRIPTION
My fault was to consider that file_name is also related to file associated with worker. But it actually isn't. So I made a patch.

Version been bumped from 1.6.4 to 1.6.6 because I pushed 1.6.5 yesterday and after it found a bug and forgot to push new version into github.