### PR TITLE
Change client according to changes in IronWorker endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    iron_worker_ng (1.6.3)
+    iron_worker_ng (1.6.7)
       bundler
       iron_core (>= 1.0.6)
       rubyzip (>= 1.0.0)

--- a/lib/iron_worker_ng/client.rb
+++ b/lib/iron_worker_ng/client.rb
@@ -453,16 +453,15 @@ EXEC_FILE
     end
 
     def clusters_get(id)
-      IronCore::Logger.debug 'IronWorkerNG', "Calling projects.get"
+      IronCore::Logger.debug 'IronWorkerNG', "Calling clusters.get"
       res = @api.clusters_get(id)['cluster']
       res['_id'] = res['id']
       OpenStruct.new(res)
     end
 
     def clusters_credentials(id)
-      IronCore::Logger.debug 'IronWorkerNG', "Calling projects.get"
-      res = @api.clusters_credentials(id)['cluster']
-      res['_id'] = res['id']
+      IronCore::Logger.debug 'IronWorkerNG', "Calling clusters.credentials"
+      res = @api.clusters_credentials(id)
       OpenStruct.new(res)
     end
 


### PR DESCRIPTION
As of now IronWorker responds with

```
{"token": "SOME_TOKEN"}
```

but lib expects 

```
{
  "cluster": {
    "token": "SOME_TOKEN"
  }
}
```