### PR TITLE
Allow to delete schedules via cancel

### DIFF
--- a/lib/iron_worker_ng/api_client.rb
+++ b/lib/iron_worker_ng/api_client.rb
@@ -147,9 +147,9 @@ module IronWorkerNG
       parse_response(put("projects/#{@project_id}/schedules/#{id}", options))
     end
 
-    def schedules_cancel(id)
+    def schedules_cancel(id, options = {})
       check_id(id)
-      parse_response(post("projects/#{@project_id}/schedules/#{id}/cancel"))
+      parse_response(post("projects/#{@project_id}/schedules/#{id}/cancel", options))
     end
 
     def projects_get

--- a/lib/iron_worker_ng/client.rb
+++ b/lib/iron_worker_ng/client.rb
@@ -429,10 +429,10 @@ EXEC_FILE
       OpenStruct.new(s)
     end
 
-    def schedules_cancel(schedule_id)
-      IronCore::Logger.debug 'IronWorkerNG', "Calling schedules.cancel with schedule_id='#{schedule_id}"
+    def schedules_cancel(schedule_id, options = {})
+      IronCore::Logger.debug 'IronWorkerNG', "Calling schedules.cancel with schedule_id='#{schedule_id}, options='#{options.to_s}'"
 
-      @api.schedules_cancel(schedule_id)
+      @api.schedules_cancel(schedule_id, options)
 
       true
     end


### PR DESCRIPTION
### What this PR changes

It changes signature of schedules_cancel method by adding optional `options` parameter keeping method backward compatible.

### Example

As of now it's possible to call this method as shown below: 

```ruby
worker_client.schedules_cancel(schedule_id, msg: 'cancelled because of my bad mood')
```

```ruby
worker_client.schedules_cancel(schedule_id, delete: true)
```
