### PR TITLE
Experimental support for synchronous tasks

### DIFF
--- a/lib/iron_worker_ng/api_client.rb
+++ b/lib/iron_worker_ng/api_client.rb
@@ -116,6 +116,17 @@ module IronWorkerNG
       end
     end
 
+    def tasks_stdout(id)
+      check_id(id)
+      if block_given?
+        stream_get("projects/#{@project_id}/tasks/#{id}/outlog") do |chunk|
+          yield chunk
+        end
+      else
+        parse_response(get("projects/#{@project_id}/tasks/#{id}/outlog"), false)
+      end
+    end
+
     def tasks_set_progress(id, options = {})
       check_id(id)
       parse_response(post("projects/#{@project_id}/tasks/#{id}/progress", options))


### PR DESCRIPTION
It's experimental support for tasks which acted as synchronous.

Usage example:

```
client = IronWorkerNG::Client.new()
payload = {}
result = client.tasks.run('iron/hello', payload, {})
```

`result` will contain a task's stdout.